### PR TITLE
feat: Enable site-wide Atom feed

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,8 @@ theme = "tabi"
 base_url = "https://blog.flix.dev/"
 compile_sass = true
 build_search_index = false
+generate_feeds = true
+feed_filenames = ["atom.xml"]
 
 taxonomies = [
     {name = "tags", feed = true},


### PR DESCRIPTION
Enables an RSS/Atom feed for the blog.

Zola was only generating per-tag feeds (`/tags/<tag>/atom.xml`, from the existing `feed = true` taxonomy settings) — there was no feed for the blog as a whole. Setting `generate_feeds = true` adds it:

```toml
generate_feeds = true
feed_filenames = ["atom.xml"]
```

## Verified

Built with Zola 0.19.2 (the version pinned in CI):

- `https://blog.flix.dev/atom.xml` is generated with all 8 posts, correct authors, dates, and permalinks
- `<link rel="alternate" type="application/atom+xml" ...>` appears in every page's `<head>`, so browsers and feed readers auto-discover it
- The RSS icon shows in the footer and on tag pages (tabi's `feed_icon` default)
- tabi's `feed_style.xsl` is referenced, so the feed renders as a readable page when opened in a browser

Entries use the post `description` as `<summary>` rather than the full text — tabi's `full_content_in_feed = false` default. Kept as-is because the compiler-errors post uses colocated images whose relative URLs would break inside a feed reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)