### PR TITLE
feat: enable RSS and Atom feeds

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,12 @@
 title = "The Flix Blog"
 theme = "tabi"
 base_url = "https://blog.flix.dev/"
+description = "The official blog of the Flix programming language."
 compile_sass = true
 build_search_index = false
+
+generate_feeds = true
+feed_filenames = ["atom.xml", "rss.xml"]
 
 taxonomies = [
     {name = "tags", feed = true},


### PR DESCRIPTION
Enables web feeds for the blog.

## What changed

`config.toml` only:

- `generate_feeds = true` — Zola only inherits a theme's `[extra]` table, not its top-level settings, so tabi's own `generate_feeds` was never taking effect.
- `feed_filenames = ["atom.xml", "rss.xml"]` — emits both, so readers expecting a literal `/rss.xml` URL are covered.
- `description` — RSS 2.0 requires a channel description; it was rendering empty.

## What the build produces

- `/atom.xml` — tabi's styled, human-readable Atom feed (this is the one the footer RSS icon links to)
- `/rss.xml` — Zola's built-in RSS 2.0 feed
- Per-tag feeds at `/tags/<tag>/atom.xml` and `/tags/<tag>/rss.xml`, since `tags` already had `feed = true`
- Autodiscovery `<link rel="alternate">` tags for both feeds in every page's `<head>`

## Notes

- Atom entries carry `<summary>` only. Add `full_content_in_feed = true` under `[extra]` if whole posts in the feed are preferred. The RSS feed already includes full content — that comes from Zola's built-in template and isn't configurable.
- No author feeds are generated despite `{name = "authors", feed = true}`: no post declares an `authors` taxonomy in its front matter, so the taxonomy is empty.

Verified with a local `zola build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)