### PR TITLE
ci: use prebuilt Zola 0.22.1 binary instead of building from source

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,56 +11,32 @@ concurrency:
   group: build-${{ github.ref }}
 
 env:
-  CARGO_TERM_COLOR: always
+  ZOLA_VERSION: 0.22.1
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR
-        uses: actions/checkout@v5
-        with:
-          path: blog-site
-          submodules: true
-      - name: Set Zola version
-        id: zola-version
-        run: echo "version=v0.19.2" >> $GITHUB_OUTPUT
-      - name: Check out Zola cargo lock (for cache key)
-        uses: actions/checkout@v5
-        with:
-          repository: getzola/zola
-          ref: ${{ steps.zola-version.outputs.version }}
-          path: zola-cargo
-          sparse-checkout: |
-            Cargo.lock
-          sparse-checkout-cone-mode: false
-      - name: Restore cached cargo builds
-        id: cargo-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('zola-cargo/Cargo.lock') }}
-      - name: Conditionally check out Zola (if version changed)
-        if: ${{ steps.cargo-cache.outputs.cache-hit != 'true' }}
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: true
-          repository: getzola/zola
-          ref: ${{ steps.zola-version.outputs.version }}
-          path: zola
-      - name: Conditionally build Zola (if no cached binary was found)
-        if: ${{ steps.cargo-cache.outputs.cache-hit != 'true' }}
-        run: cargo install --path zola/
+      - name: Install Zola
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          archive=zola-v${ZOLA_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+          curl -sSfL -o "$archive" \
+            "https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}/${archive}"
+          # The release artifacts are signed with Sigstore; refuse anything unattested.
+          gh attestation verify "$archive" --repo getzola/zola
+          tar -xzf "$archive" zola
+          sudo install -m 755 zola /usr/local/bin/zola
+          rm "$archive" zola
+          zola --version
       - name: Build site
         run: make
-        working-directory: ./blog-site
       - name: Show build output
         run: |
-          tree .
+          tree public
           cat public/404.html
-          cat public/blog/design-flaws-in-flix/index.html
-        working-directory: ./blog-site


### PR DESCRIPTION
The build workflow pinned Zola **v0.19.2** and compiled it with `cargo install`. That needed two extra checkouts — one of them a sparse checkout existing only to hash Zola's `Cargo.lock` into a cache key — plus a cargo cache to stop cold builds from dominating CI time.

Zola publishes official release tarballs, so this downloads and installs one instead. The extra checkouts, the cargo cache, and the Rust build all go away; CI drops from minutes to seconds and the cache-invalidation logic disappears with it.

## Supply chain

Zola signs its release artifacts with Sigstore, so the download is checked with `gh attestation verify` before it is installed. Verified locally: the real tarball passes (exit 0), the same tarball with one byte appended fails (exit 1). `gh` is preinstalled on `ubuntu-latest` and `github.token` covers the API call.

## Zola 0.19.2 -> 0.22.1

The only breaking change in that range is 0.22.0 replacing the Syntect highlighter with Giallo and moving highlighting config under `[markdown.highlighting]`. This site has no `[markdown]` section at all, so built-in highlighting is off and `highlight.js` from `static/` is used instead. (`themes/tabi/config.toml` does set `highlight_code = true`, but that file is the theme's example config and is never merged into the site config.) Built locally with Zola 0.22.1: 8 pages, 2 sections, no warnings.

Deliberately **not** going to 0.23.x, which is out. Upstream calls it "probably the most breaking version of Zola that will happen" — Tera v2 and shortcodes removed entirely. tabi is built on shortcodes, so that upgrade is blocked on the theme.

## Also in this change

- `actions/checkout` v5 -> v7. The only behavior change is v7 blocking fork-PR checkout under `pull_request_target`/`workflow_run`, neither of which this workflow uses.
- Dropped the `blog-site/` subdirectory checkout and both `working-directory:` settings, which only existed because Zola's source was checked out beside the site.
- Scoped `tree .` to `tree public` (it was dumping the whole repo including the vendored theme) and dropped the `cat` of one hardcoded post path, which would fail CI on a rename. The `404.html` cat stayed.
- Kept `submodules: true` even though `.gitmodules` is empty and tabi is vendored — it is a no-op today and protects the build if tabi ever returns to being a submodule.

## Note

This workflow only builds; it never deploys, and there is no `netlify.toml`/`vercel.json` in the repo. If whatever publishes blog.flix.dev pins its own Zola version, that needs bumping to 0.22.1 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)