### PR TITLE
fix: make syntax highlighting readable in dark mode

### DIFF
--- a/static/highlight.css
+++ b/static/highlight.css
@@ -1,20 +1,83 @@
-/* Licensed under the MIT license */
-/* See https://github.com/chriskempson/base16/blob/main/LICENSE.md */
 /*
- * An increased contrast highlighting scheme loosely based on the
- * "Base16 Atelier Dune Light" theme by Bram de Haan
- * (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
- * Original Base16 color scheme by Chris Kempson
- * (https://github.com/chriskempson/base16)
+ * highlight.js token colours for the Flix blog.
+ *
+ * Colours come from the Catppuccin Frappe variables that tabi defines on
+ * :root in sass/parts/_syntax_theme.scss, so highlighted blocks match the
+ * theme's own code styling and stay legible in both light and dark mode.
+ * The block background lives on `pre` -- see highlight_fix.css.
+ *
+ * Catppuccin is MIT licensed. See https://github.com/catppuccin/catppuccin
  */
 
-/* Comment */
-.hljs-comment,
-.hljs-quote {
-  color: #575757;
+.hljs {
+  display: block;
+  background: transparent;
+  color: var(--text);
+  overflow-x: auto;
 }
 
-/* Red */
+/* Comments */
+.hljs-comment,
+.hljs-quote {
+  color: var(--overlay0);
+  font-style: italic;
+}
+
+/* Keywords */
+.hljs-keyword,
+.hljs-selector-tag {
+  color: var(--mauve);
+}
+
+/* Strings */
+.hljs-string,
+.hljs-symbol,
+.hljs-bullet {
+  color: var(--green);
+}
+
+/* Interpolation inside a string returns to plain text */
+.hljs-subst {
+  color: var(--text);
+}
+
+/* Numbers */
+.hljs-number {
+  color: var(--peach);
+}
+
+/* Built-in constants: true, false, Some, None, ... */
+.hljs-literal {
+  color: var(--lavender);
+}
+
+/* Primitive types: Int32, String, Bool, ... */
+.hljs-type {
+  color: var(--yellow);
+}
+
+/* Standard library names and operators: List, println, |>, ... */
+.hljs-built_in,
+.hljs-builtin-name {
+  color: var(--sky);
+}
+
+/* Annotations: @Test, @Deprecated, ... */
+.hljs-meta {
+  color: var(--maroon);
+}
+
+/* Declaration names */
+.hljs-title,
+.hljs-section {
+  color: var(--blue);
+}
+
+.hljs-title.class_ {
+  color: var(--teal);
+}
+
+/* Scopes unused by the Flix grammar, kept for any language added later */
 .hljs-variable,
 .hljs-template-variable,
 .hljs-attribute,
@@ -22,47 +85,21 @@
 .hljs-name,
 .hljs-regexp,
 .hljs-link,
-.hljs-name,
 .hljs-selector-id,
 .hljs-selector-class {
-  color: #d70025;
+  color: var(--red);
 }
 
-/* Orange */
-.hljs-number,
-.hljs-meta,
-.hljs-built_in,
-.hljs-builtin-name,
-.hljs-literal,
-.hljs-type,
 .hljs-params {
-  color: #b21e00;
+  color: var(--rosewater);
 }
 
-/* Green */
-.hljs-string,
-.hljs-symbol,
-.hljs-bullet {
-  color: #008200;
+.hljs-addition {
+  color: var(--green);
 }
 
-/* Blue */
-.hljs-title,
-.hljs-section {
-  color: #0030f2;
-}
-
-/* Purple */
-.hljs-keyword,
-.hljs-selector-tag {
-  color: #9d00ec;
-}
-
-.hljs {
-  display: block;
-  overflow-x: auto;
-  background: #f6f7f6;
-  color: #000;
+.hljs-deletion {
+  color: var(--red);
 }
 
 .hljs-emphasis {
@@ -71,22 +108,4 @@
 
 .hljs-strong {
   font-weight: bold;
-}
-
-.hljs-addition {
-  color: #22863a;
-  background-color: #f0fff4;
-}
-
-.hljs-deletion {
-  color: #b31d28;
-  background-color: #ffeef0;
-}
-
-.hljs-subst {
-    color: #000;
-}
-
-.hljs-meta {
-    color: #b21e00;
 }

--- a/static/highlight_activate.js
+++ b/static/highlight_activate.js
@@ -1,1 +1,11 @@
+// Zola records the fence language in `data-lang`, but highlight.js reads a
+// `language-*` class. Without one it falls back to auto-detection, and since
+// this bundle only carries the Flix grammar, every block -- Scala, shell,
+// plain text -- comes out highlighted as Flix. Tag each block explicitly and
+// opt the rest out.
+document.querySelectorAll('pre code').forEach((block) => {
+    const lang = block.dataset.lang;
+    block.classList.add(lang && hljs.getLanguage(lang) ? `language-${lang}` : 'nohighlight');
+});
+
 hljs.highlightAll();

--- a/static/highlight_fix.css
+++ b/static/highlight_fix.css
@@ -1,3 +1,12 @@
-pre.language-flix {
-    background-color: #f6f7f6;
+/*
+ * highlight.js sets its classes on the `code` element, so the block background
+ * has to sit on the `pre` -- otherwise it does not cover the padding, and it
+ * only covers blocks highlight.js actually highlighted.
+ *
+ * --codeblock-bg is dark in both themes, matching tabi's own code styling, so
+ * --text (light) is the readable foreground in both.
+ */
+pre {
+    background-color: var(--codeblock-bg);
+    color: var(--text);
 }


### PR DESCRIPTION
Code blocks rendered as a light `#f6f7f6` panel with black text on the dark page background.

## Causes

**1. `highlight.css` was a hard-coded light Base16 palette.** Its `.hljs` rule (specificity 0-1-0) beat tabi's `pre code { background: transparent }` (0-0-2), so the light panel won in both themes. There was no `prefers-color-scheme` or `[data-theme]` variant anywhere in the file, and tabi's own dark syntax theme (`_syntax_theme.scss`) is inert here because it targets the `.z-*` classes Zola only emits when `highlight_code = true`.

**2. `highlight_fix.css` matched nothing.** It targeted `pre.language-flix`, but highlight.js's `cssSelector` is `"pre code"` and it adds `hljs` / `language-*` to the **`code`** element, never the `pre`. That also left the `pre`'s `1rem` inline padding outside the coloured panel, so code sat flush against the box edge.

**3. Every block was highlighted as Flix.** Zola records the fence language in `data-lang`, but highlight.js reads a `language-*` class. Without one it fell back to `highlightAuto`, and since `highlight.js` is a custom build carrying only `grmr_flix`, the Scala, Rust, shell, markdown and plain-text blocks were all lexed with the Flix grammar.

## Changes

- `static/highlight.css` — retheme tokens onto the Catppuccin variables tabi already defines unconditionally on `:root`; `.hljs` becomes `background: transparent; color: var(--text)`. Adds the scopes the Flix grammar emits but the old file never styled (`.hljs-literal`, `.hljs-title.class_`).
- `static/highlight_fix.css` — drop the dead rule; put the block background on `pre` via `var(--codeblock-bg)`, which is dark in both themes per tabi's design, plus `color: var(--text)` so blocks highlight.js skips stay readable.
- `static/highlight_activate.js` — copy `data-lang` to a `language-*` class, guarded by `hljs.getLanguage()`; anything without a bundled grammar gets `nohighlight`.

## Verification

Rendered with headless Firefox against `zola serve`:

- **Dark** `/blog/design-flaws-in-flix/` — dark panel flush under the `FLIX` bar, no light box.
- **Palette** `/blog/taming-impurity-with-polymorphic-effects/` — keywords mauve, numbers peach, strings green.
- **Non-Flix** `/blog/redundancies-as-compile-time-errors/` — the Scala block is plain and readable; `case`/`as` no longer miscoloured as Flix keywords.
- **Light** — built with `-u http://127.0.0.1:8000` and `data-theme` flipped to `light`; code blocks stay dark, matching tabi's own styling.
- **Alignment** `/blog/effect-systems-vs-print-debugging/` — the `// ^^^ empty effect set` caret comment still lines up under `{ }`.

## Note

The `pre` background rule is global, so it applies to any `<pre>` on the site, not only code fences. All current content uses `pre` solely for code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)