### PR TITLE
feat: Update vendored Flix grammar and switch highlighting to Rosé Pine Moon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # To pick up grammar changes, bump the SHA below and run `make update-grammar`.
 # The refreshed grammar lands in the working tree, where a partial or wrong
 # download shows up as a diff before it can be committed.
-GRAMMAR_COMMIT := befa883ecec4b0c84e436bdd176dec5475e584ab
+GRAMMAR_COMMIT := f4d05bbfcd34342f76bcf135f7ae58ab7cd2dd58
 GRAMMAR := syntaxes/flix.tmLanguage.json
 
 .PHONY: build-site serve update-grammar

--- a/config.toml
+++ b/config.toml
@@ -23,9 +23,13 @@ enabled = true
 style = "class"
 # The theme decides both the colours and -- since each span is named after the
 # theme rule that matched it, not after the grammar scope -- how finely the code
-# is split up. Catppuccin is the family tabi's own syntax stylesheet was derived
-# from; Mocha is its darkest member, near the value tabi gave code blocks before.
-theme = "catppuccin-mocha"
+# is split up. Two things are worth checking in a candidate, because neither is
+# visible from a screenshot of some other language: that no scope the Flix grammar
+# emits resolves back to the plain-text foreground, which is how Dracula renders
+# strings and Laserwave keywords -- unhighlighted, but only for grammars that lean
+# on that scope -- and that comments clear 3:1 against the code background, which
+# a fair number of the darker themes do not.
+theme = "rose-pine-moon"
 # The Flix grammar is not built in; `make` fetches it from flix/textmate.
 extra_grammars = ["syntaxes/flix.tmLanguage.json"]
 

--- a/syntaxes/flix.tmLanguage.json
+++ b/syntaxes/flix.tmLanguage.json
@@ -16,6 +16,9 @@
           "include": "#constants"
         },
         {
+          "include": "#declarations"
+        },
+        {
           "include": "#keywords"
         },
         {
@@ -34,6 +37,9 @@
           "include": "#annotations"
         },
         {
+          "include": "#functions"
+        },
+        {
           "include": "#types"
         },
         {
@@ -45,7 +51,7 @@
       "patterns": [
         {
           "name": "constant.language.unit.flix",
-          "match": "\\b\\(\\)\\b"
+          "match": "(?<![a-zA-Z0-9_!])\\(\\)"
         },
         {
           "name": "constant.language.bool.flix",
@@ -73,15 +79,26 @@
         }
       ]
     },
+    "declarations": {
+      "patterns": [
+        {
+          "match": "\\b(def|redef)\\s+([a-z][a-zA-Z0-9_]*!?)",
+          "captures": {
+            "1": {
+              "name": "keyword.declaration.flix"
+            },
+            "2": {
+              "name": "entity.name.function.flix"
+            }
+          }
+        }
+      ]
+    },
     "keywords": {
       "patterns": [
         {
           "name": "keyword.control.choose.flix",
           "match": "\\b(choose\\*|choose)\\b"
-        },
-        {
-          "name": "keyword.control.debug.flix",
-          "match": "\\b(dbg)\\b"
         },
         {
           "name": "keyword.control.applicativefor.flix",
@@ -109,15 +126,11 @@
         },
         {
           "name": "keyword.control.match.flix",
-          "match": "\\b(case|match|typematch|ematch)\\b"
+          "match": "\\b(case|match|ematch)\\b"
         },
         {
           "name": "keyword.control.run.flix",
           "match": "\\b(run)\\b"
-        },
-        {
-          "name": "keyword.control.resume.flix",
-          "match": "\\b(resume)\\b"
         },
         {
           "name": "keyword.control.throw.flix",
@@ -140,10 +153,6 @@
           "match": "\\b(unsafe)\\b"
         },
         {
-          "name": "keyword.control.ast.flix",
-          "match": "\\b(branch|jumpto)\\b"
-        },
-        {
           "name": "keyword.forall.flix",
           "match": "\\b(forall)\\b"
         },
@@ -161,7 +170,7 @@
         },
         {
           "name": "keyword.declaration.flix",
-          "match": "\\b(eff|def|redef|law|enum|case|type|alias|trait|instance|with|without|opaque|mod|struct|handler|xvar)\\b"
+          "match": "\\b(eff|def|redef|enum|type|alias|trait|instance|with|mod|struct)\\b"
         },
         {
           "name": "keyword.expression.cast.flix",
@@ -228,8 +237,12 @@
           "match": ";"
         },
         {
-          "name": "storage.type.modifier.flix",
-          "match": "\\b(lawful|pub|sealed|static)\\b"
+          "name": "variable.language.super.flix",
+          "match": "\\b(super)\\b"
+        },
+        {
+          "name": "storage.modifier.flix",
+          "match": "\\b(pub|sealed|static)\\b"
         }
       ]
     },
@@ -335,11 +348,30 @@
         }
       ]
     },
+    "functions": {
+      "patterns": [
+        {
+          "match": "\\b([A-Z][a-zA-Z0-9_]*)\\.([a-z][a-zA-Z0-9_]*!?)",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.flix"
+            },
+            "2": {
+              "name": "support.function.flix"
+            }
+          }
+        },
+        {
+          "name": "entity.name.function.flix",
+          "match": "\\b[a-z][a-zA-Z0-9_]*!?(?=\\s*\\()"
+        }
+      ]
+    },
     "types": {
       "patterns": [
         {
-          "name": "entity.name.type",
-          "match": "\\b(Unit|Bool|Char|Float32|Float64|Int8|Int16|Int32|Int64|BigInt|String)\\b"
+          "name": "entity.name.type.flix",
+          "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
         }
       ]
     },


### PR DESCRIPTION
Two independent changes, one commit each.

## Grammar

Bumps `GRAMMAR_COMMIT` to `f4d05bb` and re-fetches `syntaxes/flix.tmLanguage.json`. That is four commits of movement in [flix/textmate](https://github.com/flix/textmate) since `befa883`, two of which touch the grammar itself: function names, user-defined types and qualified calls are now scoped, and the keyword list has been resynced with `Lexer.scala` with the modifier scope fixed.

## Highlighting theme

Replaces `catppuccin-mocha` with `rose-pine-moon`.

Choosing a theme by eye turns out to miss something. Because each span is named after the theme rule that matched it rather than after the grammar scope, a theme can quietly resolve one of the scopes a grammar leans on back to the plain-text foreground — those tokens then render with no highlighting at all, and only for the languages that use that scope. Dracula and Synthwave '84 do this to strings; Laserwave does it to keywords; Poimandres does it to both keywords and types. None of it is apparent from the theme's own screenshots.

Every scope this grammar emits — `keyword`, `string`, `comment`, `entity.name.type`, `entity.name.function`, `constant.numeric`, `constant.language` — resolves to a distinct colour under Rosé Pine Moon. The comment on the theme key records that check, along with a second one on comment contrast, which several of the darker themes leave under 3:1 against their own code background.

One known limitation, recorded here rather than in the config since it is a trade-off and not a defect: functions, numerics and constants all resolve to `#EA9A97`, so those three do not separate from one another.

## Verification

`zola build` is clean, and the rendered posts were checked to confirm every emitted class has a matching rule in the generated stylesheet. `static/giallo.css` is gitignored and regenerated on build — note that Zola only writes it when absent, so a local checkout that already has one from a previous theme needs it deleted to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
